### PR TITLE
Remove aws login from action, remove unused github token

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,9 +11,6 @@ inputs:
   aws_secret_access_key:
     description: "aws secret access key"
     required: true
-  github_token:
-    description: "github token"
-    required: true
   version_tag:
     description: "the bumped version tag"
     required: true
@@ -28,17 +25,6 @@ runs:
       name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
-    - 
-      name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ inputs.aws_access_key_id }}
-        aws-secret-access-key: ${{ inputs.aws_secret_access_key }}
-        aws-region: us-west-2
-    - 
-      name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
     - 
       name: Cache Code Climate Binary
       id: cachecodeclimate
@@ -67,11 +53,6 @@ runs:
         docker build --build-arg NPM_TOKEN=$NPM_TOKEN --target codecov -t $CODECOV_TAG .
         docker build --build-arg NPM_TOKEN=$NPM_TOKEN -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      shell: bash
-    - 
-      name: Logout of Amazon ECR
-      if: always()
-      run: docker logout ${{ steps.login-ecr.outputs.registry }}
       shell: bash
     - 
       name: Install Helm


### PR DESCRIPTION
Removing AWS Login as this flow is necessary for installing and running telepresence for API tests. Logging in and out of AWS will be part of main workflows for now

Github token is now unnecessary due to bumping version tags being removed